### PR TITLE
ILogger Configuration

### DIFF
--- a/Generellem.Tests/DemoDocumentSourceFactoryTests.cs
+++ b/Generellem.Tests/DemoDocumentSourceFactoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using Generellem.Services;
 
+using Microsoft.Extensions.Logging;
+
 namespace Generellem.DocumentSource.Tests;
 
 public class DemoDocumentSourceFactoryTests
@@ -8,7 +10,8 @@ public class DemoDocumentSourceFactoryTests
     public void GetDocumentSources_ReturnsExpected()
     {
         Mock<IHttpClientFactory> httpClientFactMock = new();
-        DemoDocumentSourceFactory testClass = new(httpClientFactMock.Object);
+        Mock<ILogger<Website>> loggerMock = new();
+        DemoDocumentSourceFactory testClass = new(httpClientFactMock.Object, loggerMock.Object);
 
         IEnumerable<IDocumentSource> result = testClass.GetDocumentSources();
 

--- a/Generellem.Tests/Generellem.Tests.csproj
+++ b/Generellem.Tests/Generellem.Tests.csproj
@@ -9,6 +9,14 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/Generellem.Tests/PdfTests.cs
+++ b/Generellem.Tests/PdfTests.cs
@@ -6,9 +6,9 @@ public class PdfTests
 {
     const string PdfFileContents = "Test Documentation ";
 
-    Mock<Stream> streamMock = new();
+    readonly Mock<Stream> streamMock = new();
 
-    Pdf pdf = new();
+    readonly Pdf pdf = new();
 
     [Fact]
     public async Task GetTextAsync_WithValidPdf_ReturnsText()

--- a/Generellem/Document/DocumentTypes/Pdf.cs
+++ b/Generellem/Document/DocumentTypes/Pdf.cs
@@ -8,7 +8,7 @@ public class Pdf : IDocumentType
 
     public virtual List<string> SupportedExtensions => new() { ".pdf" };
 
-    public virtual async Task<string> GetTextAsync(Stream documentStream, string fileName)
+    public virtual async Task<string> GetTextAsync(Stream? documentStream, string fileName)
     {
         ArgumentNullException.ThrowIfNull(documentStream, nameof(documentStream));
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName, nameof(fileName));

--- a/Generellem/DocumentSource/DemoDocumentSourceFactory.cs
+++ b/Generellem/DocumentSource/DemoDocumentSourceFactory.cs
@@ -1,19 +1,19 @@
 ﻿using Generellem.Services;
 
+using Microsoft.Extensions.Logging;
+
 namespace Generellem.DocumentSource;
 
-public class DemoDocumentSourceFactory : IDocumentSourceFactory
+public class DemoDocumentSourceFactory(
+    IHttpClientFactory httpFact, ILogger<Website> logger) 
+    : IDocumentSourceFactory
 {
-    readonly IHttpClientFactory httpFact;
-
-    public DemoDocumentSourceFactory(IHttpClientFactory httpFact)
-    {
-        this.httpFact = httpFact;
-    }
+    readonly IHttpClientFactory httpFact = httpFact;
+    readonly ILogger<Website> logger = logger;
 
     public IEnumerable<IDocumentSource> GetDocumentSources() => 
         [
             new FileSystem(),
-            new Website(httpFact)
+            new Website(httpFact, logger)
         ];
 }

--- a/Generellem/DocumentSource/FileSystem.cs
+++ b/Generellem/DocumentSource/FileSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Runtime.CompilerServices;
+using System.Text.Json;
 
 using Generellem.Document;
 using Generellem.Document.DocumentTypes;
@@ -10,7 +11,7 @@ public class FileSystem : IDocumentSource
     readonly IEnumerable<string> DocExtensions = DocumentTypeFactory.GetSupportedDocumentTypes();
     readonly string[] ExcludedPaths = ["\\bin", "\\obj", ".git", ".vs"];
 
-    public async IAsyncEnumerable<DocumentInfo> GetDocumentsAsync(CancellationToken cancelToken)
+    public async IAsyncEnumerable<DocumentInfo> GetDocumentsAsync([EnumeratorCancellation] CancellationToken cancelToken)
     {
         IEnumerable<FileSpec> fileSpecs = await GetPathsAsync();
 
@@ -21,7 +22,7 @@ public class FileSystem : IDocumentSource
             var directories = new Queue<string>();
             directories.Enqueue(path);
 
-            while (directories.Any())
+            while (directories.Count is not 0)
             {
                 var currentDirectory = directories.Dequeue();
                 var directoryInfo = new DirectoryInfo(currentDirectory);

--- a/Generellem/Generellem.csproj
+++ b/Generellem/Generellem.csproj
@@ -6,6 +6,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.9" />
     <PackageReference Include="Azure.Search.Documents" Version="11.5.1" />
@@ -17,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="NPOI.HWPFCore" Version="2.3.0.1" />
     <PackageReference Include="PdfPig" Version="0.1.8" />
     <PackageReference Include="Polly.Core" Version="8.2.0" />

--- a/Generellem/Orchestrator/AzureOpenAIOrchestrator.cs
+++ b/Generellem/Orchestrator/AzureOpenAIOrchestrator.cs
@@ -10,6 +10,7 @@ using Generellem.Rag;
 using Generellem.Services;
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Generellem.Orchestrator;
 
@@ -22,7 +23,8 @@ namespace Generellem.Orchestrator;
 public class AzureOpenAIOrchestrator(
     IConfiguration config, 
     IDocumentSourceFactory docSourceFact, 
-    ILlm llm, 
+    ILlm llm,
+    ILogger<AzureOpenAIOrchestrator> logger,
     IRag rag) 
     : GenerellemOrchestratorBase(docSourceFact, llm, rag)
 {
@@ -123,7 +125,7 @@ public class AzureOpenAIOrchestrator(
     {
         Type UnknownType = typeof(Unknown);
 
-        Console.WriteLine($"Processing document sources...");
+        logger.LogInformation(GenerellemLogEvents.Information, $"Processing document sources...");
 
         foreach (IDocumentSource docSource in DocSources)
             await foreach (DocumentInfo doc in docSource.GetDocumentsAsync(cancelToken))
@@ -134,7 +136,7 @@ public class AzureOpenAIOrchestrator(
 
                 if (doc.DocType.GetType() != UnknownType)
                 {
-                    Console.WriteLine($"Ingesting {doc.FileRef}");
+                    logger.LogInformation(GenerellemLogEvents.Information, "Ingesting {FileRef}", doc.FileRef);
 
                     List<TextChunk> chunks = await Rag.EmbedAsync(doc.DocStream, doc.DocType, doc.FileRef, cancelToken);
                     await Rag.IndexAsync(chunks, cancelToken);

--- a/Generellem/Services/GenerellemLogEvents.cs
+++ b/Generellem/Services/GenerellemLogEvents.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Generellem.Services;
+
+/// <summary>
+/// Events that appear in Generellem ILogger output
+/// </summary>
+public static class GenerellemLogEvents
+{
+    /// <summary>
+    /// Unable to log in
+    /// </summary>
+    public static readonly EventId AuthenticationFailure = new(4401, "Authentication Error");
+
+    /// <summary>
+    /// User doesn't have permissions for a resource
+    /// </summary>
+    public static readonly EventId AuthorizationFailure = new(4403, "Authorization Failure");
+
+    /// <summary>
+    /// Caller cancelled the request
+    /// </summary>
+    public static readonly EventId Cancelled = new(4499, "Cancelled");
+
+    /// <summary>
+    /// Received an error during an HTTP request
+    /// </summary>
+    public static readonly EventId HttpError = new(4400, "HTTP Request Error");
+
+    /// <summary>
+    /// Progress/Status updates
+    /// </summary>
+    public static readonly EventId Information = new(1411, "Information");
+
+    /// <summary>
+    /// We don't have enough information to classify - look at exception details
+    /// </summary>
+    public static readonly EventId SystemFailure = new(5500, "Unknown System Failure");
+}

--- a/GenerellemConsole/GenerellemConsole.csproj
+++ b/GenerellemConsole/GenerellemConsole.csproj
@@ -8,6 +8,14 @@
     <UserSecretsId>b7980f7a-823f-4b7b-8055-67625b0122f8</UserSecretsId>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />

--- a/GenerellemConsole/GenerellemHostedService.cs
+++ b/GenerellemConsole/GenerellemHostedService.cs
@@ -1,8 +1,10 @@
 ﻿using Azure.AI.OpenAI;
 
 using Generellem.Orchestrator;
+using Generellem.Services;
 
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace GenerellemConsole;
 
@@ -11,7 +13,8 @@ namespace GenerellemConsole;
 /// </summary>
 internal class GenerellemHostedService(
     GenerellemOrchestratorBase orchestrator, 
-    IHostApplicationLifetime lifetime) 
+    IHostApplicationLifetime lifetime,
+    ILogger<GenerellemHostedService> logger)
     : IHostedService
 {
     readonly GenerellemOrchestratorBase orchestrator = orchestrator;
@@ -35,7 +38,7 @@ internal class GenerellemHostedService(
         }
         catch (OperationCanceledException opcEx)
         {
-            Console.WriteLine($"Operation Canceled - Details\n\n{opcEx}");
+            logger.LogError(GenerellemLogEvents.Cancelled, opcEx, "Operation Canceled");
         }
         finally
         {


### PR DESCRIPTION
Added ILogger support and changed Generellem to use ILogger for output, rather than Console.WriteLine. This lets the caller decide what to log via configuration.

Closes #83