### PR TITLE
Chunk ID Bug Fix

### DIFF
--- a/Generellem/Rag/TextProcessor.cs
+++ b/Generellem/Rag/TextProcessor.cs
@@ -41,7 +41,7 @@ public class TextProcessor
             chunks.Add(
                 new TextChunk()
                 {
-                    ID = Convert.ToBase64String(Encoding.UTF8.GetBytes(documentReference)),
+                    ID = Guid.NewGuid().ToString(),
                     Content = content,
                     DocumentReference = documentReference
                 });


### PR DESCRIPTION
Accidentally using the same ID on different chunks of the same document, causing the last chunk to overwrite others.

Closes #139