### PR TITLE
Chat History Updates

### DIFF
--- a/Generellem/Llm/AzureOpenAI/AzureOpenAIChatRequest.cs
+++ b/Generellem/Llm/AzureOpenAI/AzureOpenAIChatRequest.cs
@@ -7,8 +7,6 @@ namespace Generellem.Llm.AzureOpenAI;
 
 public class AzureOpenAIChatRequest : IChatRequest
 {
-    public Queue<ChatRequestUserMessage> ChatHistory { get; set; } = new();
-
     public ChatCompletionsOptions Options { get; set; } = new();
 
     public QueryDetails<AzureOpenAIChatRequest, AzureOpenAIChatResponse> SummarizedUserIntent { get; set; } = new();
@@ -29,4 +27,13 @@ public class AzureOpenAIChatRequest : IChatRequest
                 Options!.Messages[0] = new ChatRequestSystemMessage(value);
         }
     }
+
+    public static string GetRequestContent(ChatRequestMessage chatMessage) =>
+        chatMessage switch
+        {
+            ChatRequestUserMessage userMessage => userMessage.Content,
+            ChatRequestAssistantMessage assistantMessage => assistantMessage.Content,
+            _ => string.Empty
+        };
+
 }

--- a/Generellem/Processors/AzureOpenAIQuery.cs
+++ b/Generellem/Processors/AzureOpenAIQuery.cs
@@ -16,10 +16,10 @@ public class AzureOpenAIQuery(ILlm llm, IRag rag) : IGenerellemQuery
     /// </summary>
     /// <typeparam name="TResponse">Type of response with all data returned from the LLM.</typeparam>
     /// <param name="requestText">User's request</param>
-    /// <param name="chatHistory">History of questions asked to add to context</param>
+    /// <param name="chatHistory">History of questions asked/answered to add to context</param>
     /// <param name="cancelToken"><see cref="CancellationToken"/></param>
     /// <returns>Azure OpenAI response text</returns>
-    public async Task<string> AskAsync(string queryText, Queue<ChatRequestUserMessage> chatHistory, CancellationToken cancelToken)
+    public async Task<string> AskAsync(string queryText, Queue<ChatRequestMessage> chatHistory, CancellationToken cancelToken)
     {
         QueryDetails<AzureOpenAIChatRequest, AzureOpenAIChatResponse> response = 
             await PromptAsync<AzureOpenAIChatRequest, AzureOpenAIChatResponse>(queryText, chatHistory, cancelToken);
@@ -32,11 +32,11 @@ public class AzureOpenAIQuery(ILlm llm, IRag rag) : IGenerellemQuery
     /// </summary>
     /// <typeparam name="TResponse">Type of response with all data returned from the LLM.</typeparam>
     /// <param name="requestText">User's request</param>
-    /// <param name="chatHistory">History of questions asked to add to context</param>
+    /// <param name="chatHistory">History of questions asked/answered to add to context</param>
     /// <param name="cancelToken"><see cref="CancellationToken"/></param>
     /// <returns>Azure OpenAI response</returns>
     public virtual async Task<QueryDetails<TRequest, TResponse>> PromptAsync<TRequest, TResponse>(
-        string requestText, Queue<ChatRequestUserMessage> chatHistory, CancellationToken cancelToken)
+        string requestText, Queue<ChatRequestMessage> chatHistory, CancellationToken cancelToken)
         where TRequest : IChatRequest
         where TResponse : IChatResponse
     {

--- a/Generellem/Processors/IGenerellemQuery.cs
+++ b/Generellem/Processors/IGenerellemQuery.cs
@@ -17,7 +17,7 @@ public interface IGenerellemQuery
     /// <param name="cancelToken"><see cref="CancellationToken"/></param>
     /// <param name="chatHistory">History of questions asked to add to context</param>
     /// <returns>LLM response</returns>
-    Task<string> AskAsync(string queryText, Queue<ChatRequestUserMessage> chatHistory, CancellationToken cancelToken);
+    Task<string> AskAsync(string queryText, Queue<ChatRequestMessage> chatHistory, CancellationToken cancelToken);
 
     /// <summary>
     /// Performs whatever process you need to prepare a user's text and handle the response
@@ -27,7 +27,7 @@ public interface IGenerellemQuery
     /// <param name="cancelToken"><see cref="CancellationToken"/></param>
     /// <param name="chatHistory">History of questions asked to add to context</param>
     /// <returns>LLM response</returns>
-    Task<QueryDetails<TRequest, TResponse>> PromptAsync<TRequest, TResponse>(string requestText, Queue<ChatRequestUserMessage> chatHistory, CancellationToken cancelToken)
+    Task<QueryDetails<TRequest, TResponse>> PromptAsync<TRequest, TResponse>(string requestText, Queue<ChatRequestMessage> chatHistory, CancellationToken cancelToken)
         where TRequest : IChatRequest
         where TResponse : IChatResponse;
 }

--- a/Generellem/Rag/IRag.cs
+++ b/Generellem/Rag/IRag.cs
@@ -38,7 +38,7 @@ public interface IRag
     /// <param name="cancelToken"><see cref="CancellationToken"/></param>
     /// 
     /// <returns>Full request that can be sent to the LLM.</returns>
-    Task<TRequest> BuildRequestAsync<TRequest>(string requestText, Queue<ChatRequestUserMessage> chatHistory, CancellationToken cancelToken)
+    Task<TRequest> BuildRequestAsync<TRequest>(string requestText, Queue<ChatRequestMessage> chatHistory, CancellationToken cancelToken)
         where TRequest : IChatRequest, new();
 
     /// <summary>


### PR DESCRIPTION
Since we want to work with both user and assistant messages, this changes the history type to their ChatRequestMessage base class. Since this base class only lets us read the Role, I added a utility method to AzureOpenAIChatRequest to get the content based on the request type. Also removed some history management logic, instead leaving that to the calling code to decide how history is managed.

Closes #143