### PR TITLE
Refactored instantiation of AzureOpenAIClient so that it happens just…

### DIFF
--- a/Generellem/Embedding/AzureOpenAI/AzureOpenAIEmbedding.cs
+++ b/Generellem/Embedding/AzureOpenAI/AzureOpenAIEmbedding.cs
@@ -22,8 +22,6 @@ public class AzureOpenAIEmbedding(
 {
     static IProgress<IngestionProgress>? currentProgress = null;
 
-    readonly OpenAIClient openAIClient = llmClientFact.CreateOpenAIClient();
-
     public ResiliencePipeline Pipeline { get; set; } =
         new ResiliencePipelineBuilder()
             .AddRetry(new()
@@ -70,9 +68,11 @@ public class AzureOpenAIEmbedding(
 
             try
             {
+                OpenAIClient openAiClient = llmClientFact.CreateOpenAIClient();
+
                 EmbeddingsOptions embeddingsOptions = GetEmbeddingOptions(chunk.Content);
                 Response<Embeddings> embeddings = await Pipeline.ExecuteAsync<Response<Embeddings>>(
-                    async token => await openAIClient.GetEmbeddingsAsync(embeddingsOptions, token),
+                    async token => await openAiClient.GetEmbeddingsAsync(embeddingsOptions, token),
                     cancellationToken);
 
                 chunk.Embedding = embeddings.Value.Data[0].Embedding;

--- a/Generellem/Llm/AzureOpenAI/AzureOpenAILlm.cs
+++ b/Generellem/Llm/AzureOpenAI/AzureOpenAILlm.cs
@@ -14,8 +14,6 @@ public class AzureOpenAILlm(LlmClientFactory llmClientFact, ILogger<AzureOpenAIL
 {
     readonly ILogger<AzureOpenAILlm> logger = logger;
 
-    readonly OpenAIClient openAIClient = llmClientFact.CreateOpenAIClient();
-
     public ResiliencePipeline Pipeline { get; set; } = 
         new ResiliencePipelineBuilder()
             .AddRetry(new RetryStrategyOptions())
@@ -30,8 +28,10 @@ public class AzureOpenAILlm(LlmClientFactory llmClientFact, ILogger<AzureOpenAIL
 
         try
         {
+            OpenAIClient openAiClient = llmClientFact.CreateOpenAIClient();
+
             ChatCompletions chatCompletionsResponse = await Pipeline.ExecuteAsync<ChatCompletions>(
-                async token => await openAIClient.GetChatCompletionsAsync(completionsOptions, token),
+                async token => await openAiClient.GetChatCompletionsAsync(completionsOptions, token),
                 cancellationToken);
 
             IChatResponse chatResponse = new AzureOpenAIChatResponse(chatCompletionsResponse);

--- a/Generellem/Rag/AzureOpenAI/AzureOpenAIRag.cs
+++ b/Generellem/Rag/AzureOpenAI/AzureOpenAIRag.cs
@@ -53,8 +53,6 @@ public class AzureOpenAIRag(
     /// </summary>
     public float Temperature { get; set; } = 0;
 
-    readonly OpenAIClient openAIClient = llmClientFact.CreateOpenAIClient();
-
     public ResiliencePipeline Pipeline { get; set; } = 
         new ResiliencePipelineBuilder()
             .AddRetry(new()
@@ -164,8 +162,10 @@ public class AzureOpenAIRag(
 
         try
         {
+            OpenAIClient openAiClient = llmClientFact.CreateOpenAIClient();
+
             Response<Embeddings> embeddings = await Pipeline.ExecuteAsync<Response<Embeddings>>(
-            async token => await openAIClient.GetEmbeddingsAsync(embeddingsOptions, token),
+            async token => await openAiClient.GetEmbeddingsAsync(embeddingsOptions, token),
                 cancellationToken);
 
             ReadOnlyMemory<float> embedding = embeddings.Value.Data[0].Embedding;


### PR DESCRIPTION
… before it's used, rather than object construction time. Removes a potential race condition where instance creation occurs prior to usage, causing errors because of missing/invalid configuration.