### PR TITLE
One Drive empty filespec login bug

### DIFF
--- a/Generellem/DocumentSource/OneDriveFileSystem.cs
+++ b/Generellem/DocumentSource/OneDriveFileSystem.cs
@@ -51,13 +51,16 @@ public class OneDriveFileSystem : IDocumentSource
     /// <returns>Enumerable of <see cref="DocumentInfo"/>.</returns>
     public async IAsyncEnumerable<DocumentInfo> GetDocumentsAsync([EnumeratorCancellation] CancellationToken cancelToken)
     {
+        IEnumerable<PathSpec> fileSpecs = await pathProvider.GetPathsAsync($"{nameof(OneDriveFileSystem)}.json");
+
+        if (fileSpecs is null || fileSpecs.Count() == 0)
+            yield break;
+
         GraphServiceClient graphClient = await msGraphFact.CreateAsync(Scopes.OneDrive);
         User? user = await graphClient.Me.GetAsync();
 
         if (user is not null)
             Prefix = $"{user.DisplayName}:{nameof(OneDriveFileSystem)}";
-
-        IEnumerable<PathSpec> fileSpecs = await pathProvider.GetPathsAsync($"{nameof(OneDriveFileSystem)}.json");
 
         foreach (PathSpec spec in fileSpecs)
         {

--- a/MSGraphDemo/MSGraphDemo.csproj
+++ b/MSGraphDemo/MSGraphDemo.csproj
@@ -23,6 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="OneDriveFileSystem - Copy.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="OneDriveFileSystem.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/MSGraphDemo/OneDriveFileSystem - Copy.json
+++ b/MSGraphDemo/OneDriveFileSystem - Copy.json
@@ -1,0 +1,6 @@
+[
+  {
+    "description": "OneDrive Generellem Files",
+    "path": "/Documents/Generellem"
+  }
+]


### PR DESCRIPTION
Fixed bug with onedrive asking to log in when there aren't any file specs.

Closes #161 